### PR TITLE
add setting page and some details

### DIFF
--- a/LoginPage.qml
+++ b/LoginPage.qml
@@ -150,6 +150,19 @@ Page {
         }
     }
 
+    Dialog {
+        id: shutDownDialog
+        width: Units.dp(300)
+        text: "确定要关机吗?"
+        hasActions: true
+        positiveButtonText: "确定"
+        negativeButtonText: "取消"
+
+        onAccepted: {
+            Qt.quit()
+        }
+    }
+
     Row {
         anchors {
             bottom: parent.bottom
@@ -160,18 +173,32 @@ Page {
 
         spacing: 32
 
-        IconButton {
+        Action {
+            id: rebootAction
             iconName: "navigation/refresh"
+            text: "重启"
+        }
+
+        Action {
+            id: shutDownAction
+            iconName: "action/power_settings_new"
+            text: "关机"
+        }
+
+        IconButton {
+            action: rebootAction
             size: 32
+            hoverAnimation: true
             color: Theme.light.iconColor
         }
 
         IconButton {
-            iconName: "action/power_settings_new"
+            action: shutDownAction
             size: 32
             color: Theme.light.iconColor
+            hoverAnimation: true
             onClicked: {
-                Qt.quit();
+                shutDownDialog.show()
             }
         }
     }
@@ -186,11 +213,18 @@ Page {
 
         spacing: 32
 
-        IconButton {
+        Action {
+            id: settingAction
             iconName: "action/settings"
+            text: "系统设置"
+        }
+
+        IconButton {
+            action: settingAction
             size: 32
             hoverAnimation: true
             color: Theme.light.iconColor
+            onClicked: pageStack.push(Qt.resolvedUrl("SettingPage.qml"))
         }
     }
 }

--- a/SettingPage.qml
+++ b/SettingPage.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.4
+import Material 0.2
+import Material.ListItems 0.1 as ListItem
+
+Page {
+    id: settingpage
+    title: "设置"
+
+    Button {
+        anchors.centerIn: parent
+        text: "返回登录"
+        onClicked: pageStack.push(Qt.resolvedUrl("LoginPage.qml"))
+    }
+
+    rightSidebar: PageSidebar {
+        title: "选项"
+
+        width: Units.dp(320)
+
+    }
+}
+

--- a/SettingPage.qml
+++ b/SettingPage.qml
@@ -6,12 +6,6 @@ Page {
     id: settingpage
     title: "设置"
 
-    Button {
-        anchors.centerIn: parent
-        text: "返回登录"
-        onClicked: pageStack.push(Qt.resolvedUrl("LoginPage.qml"))
-    }
-
     rightSidebar: PageSidebar {
         title: "选项"
 

--- a/qml.qrc
+++ b/qml.qrc
@@ -2,5 +2,6 @@
     <qresource prefix="/">
         <file>main.qml</file>
         <file>LoginPage.qml</file>
+        <file>SettingPage.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
#7 @solarsail @woqidaideshi

1，在设置按钮上添加了一个设置page，之前想的是用sidebar弹出一个设置框，后来觉得还是单独在一个页面中比较好，右边留了一个sidebar，可以区分设置选项。
2，添加了一些按钮的说明，如重启，关机。

测试方法：

更新最新代码，重新构建项目，运行。

待完成：

都需要设置哪些内容，页面设计布局？
