### PR TITLE
实现心跳连接

### DIFF
--- a/DesktopPage.qml
+++ b/DesktopPage.qml
@@ -8,6 +8,8 @@ import com.evercloud.http 0.1
 Page {
     id: desktop_selection
 
+    property bool heartbeat_error: false
+
     Component.onCompleted: {
         parse_info();
         heartbeat.startSending(UserConnection.token);
@@ -69,8 +71,13 @@ Page {
 
         onFinished: {
             var code = rdp.status();
-            if (code !== 0)
+            if (code !== 0) {
                 prompt.open("连接错误：" + rdp.status())
+            }
+            if (desktop_selection.heartbeat_error) { // 心跳异常，需要重新登录
+                desktop_selection.pop();
+            }
+
             heartbeat.startSending(UserConnection.token);
         }
     }
@@ -97,10 +104,9 @@ Page {
     HeartBeat {
         id: heartbeat
         url: "http://192.168.1.41:8893/heartbeat"
-        onError: {
+        onError: { // 心跳异常
             heartbeat.stop();
-            rdp.kill();
-            desktop_selection.pop();
+            desktop_selection.heartbeat_error = true;
         }
     }
 

--- a/DesktopPage.qml
+++ b/DesktopPage.qml
@@ -8,6 +8,13 @@ import com.evercloud.http 0.1
 Page {
     id: desktop_selection
 
+    backAction: Action {
+        text: "返回"
+        iconName: "navigation/arrow_back"
+        onTriggered: desktop_selection.pop()
+        visible: canGoBack
+    }
+
     property bool heartbeat_error: false
 
     Component.onCompleted: {

--- a/Foldex-Eye.pro
+++ b/Foldex-Eye.pro
@@ -5,7 +5,8 @@ CONFIG += c++11
 
 SOURCES += main.cpp \
     httprequest.cpp \
-    rdpprocess.cpp
+    rdpprocess.cpp \
+    heartbeat.cpp
 
 RESOURCES += qml.qrc
 
@@ -17,7 +18,8 @@ include(deployment.pri)
 
 HEADERS += \
     httprequest.h \
-    rdpprocess.h
+    rdpprocess.h \
+    heartbeat.h
 
 isEmpty(TARGET_EXT) {
     win32 {

--- a/heartbeat.cpp
+++ b/heartbeat.cpp
@@ -1,0 +1,72 @@
+#include "heartbeat.h"
+
+HeartBeat::HeartBeat(QObject *parent) :
+    QObject(parent), _interval(8000), _timer(new QTimer(this))
+{
+    connect(_timer, SIGNAL(timeout()), this, SLOT(heartbeat()));
+    connect(&_req, SIGNAL(codeChanged(int)), this, SLOT(handleResponse(int)));
+    connect(&_req, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(handleError()));
+}
+
+void HeartBeat::startSending(const QString &token, const QString &vm_id)
+{
+    QString json;
+    json.append("{ ").append("\"token\": ").append("\"").append(token).append("\", ");
+    json.append("\"vm_id\": ").append("\"").append(vm_id).append("\"").append(" }");
+
+    _req.setJsonData(json);
+
+    _timer->start(_interval);
+}
+
+void HeartBeat::startSending(const QString &token)
+{
+    QString json;
+    json.append("{ ").append("\"token\": ").append("\"").append(token).append("\" }");
+
+    _req.setJsonData(json);
+
+    _timer->start(_interval);
+}
+
+void HeartBeat::stop()
+{
+    _timer->stop();
+}
+
+QString HeartBeat::url() const
+{
+    return _req.url();
+}
+
+int HeartBeat::interval() const
+{
+    return _interval / 1000;
+}
+
+void HeartBeat::setUrl(QString url)
+{
+    _req.setUrl(url);
+}
+
+void HeartBeat::setInterval(int interval)
+{
+    _interval = interval * 1000;
+}
+
+void HeartBeat::handleResponse(int code)
+{
+    if (code != 204) {
+        emit error();
+    }
+}
+
+void HeartBeat::handleError()
+{
+    emit error();
+}
+
+void HeartBeat::heartbeat()
+{
+    _req.sendJson();
+}

--- a/heartbeat.h
+++ b/heartbeat.h
@@ -1,0 +1,45 @@
+#ifndef HEARTBEAT_H
+#define HEARTBEAT_H
+
+#include <QObject>
+#include <QTimer>
+#include "httprequest.h"
+
+class HeartBeat : public QObject
+{
+    Q_OBJECT
+
+    HTTPRequest _req;
+    int _interval;
+
+    QTimer *_timer;
+    QString _json;
+
+public:
+    explicit HeartBeat(QObject *parent = 0);
+
+    // 服务器地址
+    Q_PROPERTY(QString url READ url WRITE setUrl)
+    // 发送间隔（秒）
+    Q_PROPERTY(int interval READ interval WRITE setInterval)
+
+    Q_INVOKABLE void startSending(const QString &token, const QString &vm_id);
+    Q_INVOKABLE void startSending(const QString &token);
+    Q_INVOKABLE void stop();
+
+    QString url() const;
+    int interval() const;
+
+signals:
+    void error();
+
+public slots:
+    void setUrl(QString url);
+    void setInterval(int interval);
+    void handleResponse(int code);
+    void handleError();
+    void heartbeat();
+
+};
+
+#endif // HEARTBEAT_H

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 #include <QSslSocket>
 #include "httprequest.h"
 #include "rdpprocess.h"
+#include "heartbeat.h"
 
 void test_ssl()
 {
@@ -14,13 +15,15 @@ void test_ssl()
 static QJSValue conn_singleton_provider(QQmlEngine *engine, QJSEngine *scriptEngine)
 {
     Q_UNUSED(engine)
-    static QString username, password, info, host;
+    static QString username, password, info, host, vm, token;
 
     QJSValue profile = scriptEngine->newObject();
     profile.setProperty("username", username);
     profile.setProperty("password", password);
     profile.setProperty("info", info);
     profile.setProperty("currentHost", host);
+    profile.setProperty("currentVm", vm);
+    profile.setProperty("token", token);
     return profile;
 }
 
@@ -34,6 +37,7 @@ int main(int argc, char *argv[])
     // 注册 C++ 插件类
     qmlRegisterType<HTTPRequest>("com.evercloud.http", 0, 1, "Request");
     qmlRegisterType<RDPProcess>("com.evercloud.rdp", 0, 1, "RDPProcess");
+    qmlRegisterType<HeartBeat>("com.evercloud.conn", 0, 1, "HeartBeat");
     qmlRegisterSingletonType("com.evercloud.conn", 0, 1, "UserConnection", conn_singleton_provider);
 
     QGuiApplication app(argc, argv);

--- a/main.cpp
+++ b/main.cpp
@@ -45,9 +45,9 @@ int main(int argc, char *argv[])
     QQmlApplicationEngine engine;
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
 
-    //QWindowList windows = QGuiApplication::topLevelWindows();
-    //QWindow *main_window = windows[0];
-    //main_window->showFullScreen();
+    QWindowList windows = QGuiApplication::topLevelWindows();
+    QWindow *main_window = windows[0];
+    main_window->showFullScreen();
 
     return app.exec();
 }

--- a/rdpprocess.cpp
+++ b/rdpprocess.cpp
@@ -34,6 +34,11 @@ QString RDPProcess::errorCode() const
     return this->errorString();
 }
 
+void RDPProcess::kill()
+{
+    QProcess::kill();
+}
+
 QString RDPProcess::username() const
 {
     return _username;

--- a/rdpprocess.h
+++ b/rdpprocess.h
@@ -34,6 +34,7 @@ public:
 
 
 public slots:
+    Q_INVOKABLE void kill();
     void setUsername(QString username);
     void setPassword(QString password);
     void setHost(QString host);


### PR DESCRIPTION
resolve #11 

@rtty122333 

实现 #11 中的功能点。

测试：

首先编译运行。

[A]
1. 启动服务
2. 登录
3. 服务端可见含 `token` 的心跳日志
4. 连接到桌面
5. 服务端可见含 `token` 和 `vm_id` 的心跳日志
6. 关闭桌面连接，停留在桌面选择界面
7. 服务端可见含 `token` 的心跳日志
8. 返回登录界面
9. 服务端可见心跳日志已停止

[B]
1. 启动服务
2. 登录
3. 连接到桌面
4. 关闭服务，桌面连接仍保持
5. 稍后关闭桌面连接
6. 可见已返回登录界面
