### PR TITLE
修改设置页面返回按钮提示

### DIFF
--- a/SettingPage.qml
+++ b/SettingPage.qml
@@ -6,6 +6,13 @@ Page {
     id: settingpage
     title: "设置"
 
+    backAction: Action {
+        text: "返回"
+        iconName: "navigation/arrow_back"
+        onTriggered: settingpage.pop()
+        visible: canGoBack
+    }
+
     rightSidebar: PageSidebar {
         title: "选项"
 


### PR DESCRIPTION
@rtty122333 

改为“返回”。

测试：
1. 编译运行
2. 进入设置页面
3. 检查返回按钮的提示

参考：`qml/Material/Page.qml`

```
id: page
...
property Action backAction: Action {
    name: "Back"
    iconName: "navigation/arrow_back"
    onTriggered: page.pop()
    visible: canGoBack
}
```
