### PR TITLE
设置统一的默认字体

### DIFF
--- a/LoginPage.qml
+++ b/LoginPage.qml
@@ -40,7 +40,6 @@ Page {
                 text: "登录"
 
                 color: "white"
-                font.family: "微软雅黑 Light"
                 font.pixelSize: 48
 
                 anchors {
@@ -57,7 +56,6 @@ Page {
 
             placeholderText: "用户名"
             floatingLabel: true
-            font.family: "微软雅黑 Light"
             font.pixelSize: 24
 
             onTextChanged: {
@@ -78,7 +76,6 @@ Page {
             placeholderText: "密码"
             floatingLabel: true
             echoMode: TextInput.Password
-            font.family: "微软雅黑 Light"
             font.pixelSize: 24
 
             onTextChanged: {
@@ -110,7 +107,6 @@ Page {
 
             Label {
                 text: "记住用户名"
-                font.family: "微软雅黑 Light"
                 anchors.verticalCenter: keep_username.verticalCenter
             }
 
@@ -128,7 +124,6 @@ Page {
 
             Label {
                 text: "记住密码"
-                font.family: "微软雅黑 Light"
                 anchors.verticalCenter: keep_password.verticalCenter
             }
         }

--- a/main.cpp
+++ b/main.cpp
@@ -21,6 +21,8 @@ int main(int argc, char *argv[])
     qmlRegisterType<HTTPRequest>("com.evercloud.http", 0, 1, "Request");
 
     QGuiApplication app(argc, argv);
+    QFont msyh_light("微软雅黑 Light");
+    app.setFont(msyh_light);
 
     QQmlApplicationEngine engine;
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));

--- a/patch/0001-unset-default-font-previously-Roboco.patch
+++ b/patch/0001-unset-default-font-previously-Roboco.patch
@@ -1,0 +1,37 @@
+From 58accf3994ee00692c84962f9dcdcebc6086217d Mon Sep 17 00:00:00 2001
+From: solarsail <newleaf.lu@gmail.com>
+Date: Thu, 28 Apr 2016 15:41:50 +0800
+Subject: [PATCH] unset default font (previously Roboco)
+
+---
+ modules/Material/Label.qml                                  | 1 -
+ modules/QtQuick/Controls/Styles/Material/TextFieldStyle.qml | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/modules/Material/Label.qml b/modules/Material/Label.qml
+index f120a8c..23f5c95 100644
+--- a/modules/Material/Label.qml
++++ b/modules/Material/Label.qml
+@@ -110,7 +110,6 @@ Text {
+ 
+     font.pixelSize: Units.dp(!Device.isMobile && fontInfo.size_desktop 
+             ? fontInfo.size_desktop : fontInfo.size)
+-    font.family: "Roboto"
+     font.weight: {
+         var weight = fontInfo.font
+ 
+diff --git a/modules/QtQuick/Controls/Styles/Material/TextFieldStyle.qml b/modules/QtQuick/Controls/Styles/Material/TextFieldStyle.qml
+index af47687..4131e54 100644
+--- a/modules/QtQuick/Controls/Styles/Material/TextFieldStyle.qml
++++ b/modules/QtQuick/Controls/Styles/Material/TextFieldStyle.qml
+@@ -32,7 +32,6 @@ TextFieldStyle {
+     }
+ 
+     font {
+-        family: echoMode == TextInput.Password ? "Default" : "Roboto"
+         pixelSize: Units.dp(16)
+     }
+ 
+-- 
+2.7.1.windows.2
+


### PR DESCRIPTION
@rtty122333 

在 `main.cpp` 中统一设置默认字体“微软雅黑 Light”。

Material 库中硬编码了默认字体“Roboto”，需要将其删除。

测试：
1. 对 Material 库应用补丁
2. 编译运行
