### PR TITLE
实现设置页面切换

### DIFF
--- a/SettingPage.qml
+++ b/SettingPage.qml
@@ -60,7 +60,6 @@ Page {
             anchors.fill: parent
             asynchronous: true
             visible: status == Loader.Ready
-            // selectedComponent will always be valid, as it defaults to the first component
             source: {
                 return Qt.resolvedUrl(("%1%2").arg("settingPage/").arg(settingName[settingpage.selectedComponent].url))
             }

--- a/SettingPage.qml
+++ b/SettingPage.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.4
 import Material 0.2
 import Material.ListItems 0.1 as ListItem
+import QtQml 2.2
 
 Page {
     id: settingpage
@@ -13,11 +14,56 @@ Page {
         visible: canGoBack
     }
 
-    rightSidebar: PageSidebar {
-        title: "选项"
+    property int selectedComponent: 0
+    property var settingName: [{
+            name: "网络设置",
+            url: "network.qml"
+        }, {
+            name: "服务器配置",
+            url: "server.qml"
+        }, {
+            name: "协议配置",
+            url: "protocol.qml"
+        }]
 
+    Sidebar {
+        id: settingside
         width: Units.dp(320)
+        Column {
+            width: parent.width
+            spacing: 2
 
+            Repeater {
+                model: settingName
+                delegate: ListItem.Standard {
+                    text: settingName[index].name
+                    selected: index == settingpage.selectedComponent
+                    onClicked: {
+                        settingpage.selectedComponent = index
+                        console.log(settingName[index].url)
+                    }
+                }
+            }
+        }
+    }
+
+    Item {
+        id: flickable
+        anchors {
+            left: settingside.right
+            right: parent.right
+            top: parent.top
+            bottom: parent.bottom
+        }
+        Loader {
+            id: example
+            anchors.fill: parent
+            asynchronous: true
+            visible: status == Loader.Ready
+            // selectedComponent will always be valid, as it defaults to the first component
+            source: {
+                return Qt.resolvedUrl(("%1%2").arg("settingPage/").arg(settingName[settingpage.selectedComponent].url))
+            }
+        }
     }
 }
-

--- a/qml.qrc
+++ b/qml.qrc
@@ -4,5 +4,8 @@
         <file>LoginPage.qml</file>
         <file>SettingPage.qml</file>
         <file>DesktopPage.qml</file>
+        <file>settingPage/network.qml</file>
+        <file>settingPage/protocol.qml</file>
+        <file>settingPage/server.qml</file>
     </qresource>
 </RCC>

--- a/settingPage/network.qml
+++ b/settingPage/network.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.4
+import Material 0.2
+import QtQuick.Controls 1.3 as Controls
+
+Item {
+
+    Column {
+        anchors.centerIn: parent
+        spacing: Units.dp(20)
+
+        Button {
+            text: "网络设置"
+            anchors.horizontalCenter: parent.horizontalCenter
+            onClicked: snackbar.open("网络设置页面，待完善")
+        }
+    }
+
+    Snackbar {
+        id: snackbar
+    }
+}

--- a/settingPage/protocol.qml
+++ b/settingPage/protocol.qml
@@ -1,0 +1,25 @@
+import QtQuick 2.4
+import Material 0.2
+import QtQuick.Controls 1.3 as Controls
+
+Item {
+
+    Column {
+        anchors.centerIn: parent
+        spacing: Units.dp(20)
+
+        Button {
+            text: "协议设置"
+            elevation: 1
+            activeFocusOnPress: true
+            backgroundColor: Theme.primaryColor
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            onClicked: snackbar.open("协议设置，待完善")
+        }
+    }
+
+    Snackbar {
+        id: snackbar
+    }
+}

--- a/settingPage/server.qml
+++ b/settingPage/server.qml
@@ -1,0 +1,25 @@
+import QtQuick 2.4
+import Material 0.2
+import QtQuick.Controls 1.3 as Controls
+
+Item {
+
+    Column {
+        anchors.centerIn: parent
+        spacing: Units.dp(20)
+
+        Button {
+            text: "服务器设置"
+            elevation: 1
+            activeFocusOnPress: true
+            backgroundColor: Theme.primaryColor
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            onClicked: snackbar.open("服务器设置，待完善")
+        }
+    }
+
+    Snackbar {
+        id: snackbar
+    }
+}


### PR DESCRIPTION
#7 @solarsail @woqidaideshi

实现了设置页面的不同tab切换，其中页面放在settingPage目录里，新增或者删除页面，可以修改SettingPage的 property var settingName 属性。

测试方法：

将新添加的settingPage目录下的文件添加到QtCreater工程里，重新编译运行。

待完善：

完善每个设置页面的细节和相应功能。
