### PR TITLE
保存登陆配置

### DIFF
--- a/LoginPage.qml
+++ b/LoginPage.qml
@@ -179,14 +179,6 @@ Page {
                 request.url = "http://192.168.1.41:8893/login";
                 request.jsonData = JSON.stringify({ 'username': username.text, 'password': password.text });
                 request.sendJson();
-                //保存当前用户名或密码逻辑
-                if((keep_username.checked == true)&&(keep_password.checked == false)){
-                    usersetting.storeUser(username.text,'');
-                }else if((keep_username.checked == true)&&(keep_password.checked == true)){
-                    usersetting.storeUser(username.text,password.text)
-                }else if(keep_username.checked == false){
-                    usersetting.storeUser('','')
-                }
             }
 
             function input_is_valid() {
@@ -212,6 +204,14 @@ Page {
         negativeButtonText: "取消"
 
         onAccepted: {
+            //保存当前用户名或密码逻辑
+            if((keep_username.checked == true)&&(keep_password.checked == false)){
+                usersetting.storeUser(username.text,'');
+            }else if((keep_username.checked == true)&&(keep_password.checked == true)){
+                usersetting.storeUser(username.text,password.text)
+            }else if(keep_username.checked == false){
+                usersetting.storeUser('','')
+            }
             Qt.quit()
         }
     }

--- a/LoginPage.qml
+++ b/LoginPage.qml
@@ -2,9 +2,14 @@ import QtQuick 2.4
 import Material 0.2
 import com.evercloud.http 0.1
 import com.evercloud.conn 0.1
+import "./settingPage"
 
 Page {
     actionBar.hidden: true
+
+    Settingstore {
+        id: usersetting
+    }
 
     View { // 背景卡片
         radius: 3
@@ -104,6 +109,14 @@ Page {
             Switch {
                 id: keep_username
                 checked: false
+                onCheckedChanged: function(){
+                    if(keep_username.checked == true){
+                       keep_password.enabled = true;
+                    } else {
+                        keep_password.checked = false;
+                       keep_password.enabled = false;
+                    }
+                }
             }
 
             Label {
@@ -119,6 +132,7 @@ Page {
             }
 
             Switch {
+                enabled: false
                 id: keep_password
                 checked: false
             }
@@ -126,6 +140,18 @@ Page {
             Label {
                 text: "记住密码"
                 anchors.verticalCenter: keep_password.verticalCenter
+            }
+
+            Component.onCompleted:{
+                if(usersetting.user !== ''){
+                    username.text = usersetting.user;
+                    keep_username.checked = true;
+                }
+
+                if(usersetting.passwd !== ''){
+                    password.text = usersetting.passwd;
+                    keep_password.checked = true;
+                }
             }
         }
 
@@ -153,6 +179,14 @@ Page {
                 request.url = "http://192.168.1.41:8893/login";
                 request.jsonData = JSON.stringify({ 'username': username.text, 'password': password.text });
                 request.sendJson();
+                //保存当前用户名或密码逻辑
+                if((keep_username.checked == true)&&(keep_password.checked == false)){
+                    usersetting.storeUser(username.text,'');
+                }else if((keep_username.checked == true)&&(keep_password.checked == true)){
+                    usersetting.storeUser(username.text,password.text)
+                }else if(keep_username.checked == false){
+                    usersetting.storeUser('','')
+                }
             }
 
             function input_is_valid() {

--- a/LoginPage.qml
+++ b/LoginPage.qml
@@ -69,6 +69,13 @@ Page {
 
             onTextChanged: {
                 username.hasError = false
+
+                if (username.text === "") {
+                    keep_username.checked = false
+                    keep_username.enabled = false
+                } else {
+                    keep_username.enabled = true
+                }
             }
 
             width: 300
@@ -137,7 +144,6 @@ Page {
             }
 
             Switch {
-                enabled: false
                 id: keep_password
                 checked: true
             }
@@ -156,10 +162,8 @@ Page {
 
                 if (usersetting.passwd !== '') {
                     password.text = usersetting.passwd
-                    keep_password.enabled = true
                     keep_password.checked = true
                 } else {
-                    keep_password.enabled = false
                     keep_password.checked = false
                 }
             }
@@ -226,6 +230,7 @@ Page {
             } else if ((keep_username.checked == true)
                        && (keep_password.checked == true)
                        && (username.text !== '')) {
+
                 usersetting.storeUser(username.text, password.text)
             } else if (keep_username.checked == false) {
                 usersetting.storeUser('', '')

--- a/LoginPage.qml
+++ b/LoginPage.qml
@@ -11,7 +11,8 @@ Page {
         id: usersetting
     }
 
-    View { // 背景卡片
+    View {
+        // 背景卡片
         radius: 3
         width: 400
         height: 500
@@ -19,7 +20,8 @@ Page {
         backgroundColor: "white"
         anchors.centerIn: parent
 
-        View { // 标题板
+        View {
+            // 标题板
             id: caption
 
             width: parent.width
@@ -57,7 +59,8 @@ Page {
             }
         }
 
-        TextField { // 用户名输入框
+        TextField {
+            // 用户名输入框
             id: username
 
             placeholderText: "用户名"
@@ -76,7 +79,8 @@ Page {
             }
         }
 
-        TextField { // 密码输入框
+        TextField {
+            // 密码输入框
             id: password
 
             placeholderText: "密码"
@@ -97,7 +101,8 @@ Page {
             }
         }
 
-        Row { // 开关栏
+        Row {
+            // 开关栏
             anchors {
                 horizontalCenter: parent.horizontalCenter
                 top: password.bottom
@@ -109,12 +114,12 @@ Page {
             Switch {
                 id: keep_username
                 checked: true
-                onCheckedChanged: function(){
-                    if(keep_username.checked == true){
-                       keep_password.enabled = true;
+                onCheckedChanged: function () {
+                    if (keep_username.checked == true) {
+                        keep_password.enabled = true
                     } else {
-                        keep_password.checked = false;
-                       keep_password.enabled = false;
+                        keep_password.checked = false
+                        keep_password.enabled = false
                     }
                 }
             }
@@ -141,33 +146,34 @@ Page {
                 text: "记住密码"
                 anchors.verticalCenter: keep_password.verticalCenter
             }
-            Component.onCompleted:{
-                if(usersetting.user !== ''){
-                    username.text = usersetting.user;
-                    keep_username.checked = true;
-                }else{
-                    keep_username.checked = false;
+            Component.onCompleted: {
+                if (usersetting.user !== '') {
+                    username.text = usersetting.user
+                    keep_username.checked = true
+                } else {
+                    keep_username.checked = false
                 }
 
-                if(usersetting.passwd !== ''){
-                    password.text = usersetting.passwd;
-                    keep_password.enabled = true;
-                    keep_password.checked = true;
-                }else{
-                    keep_password.enabled = false;
-                    keep_password.checked = false;
+                if (usersetting.passwd !== '') {
+                    password.text = usersetting.passwd
+                    keep_password.enabled = true
+                    keep_password.checked = true
+                } else {
+                    keep_password.enabled = false
+                    keep_password.checked = false
                 }
             }
-
         }
 
-        ProgressCircle { // 登录过程中显示进度圈
+        ProgressCircle {
+            // 登录过程中显示进度圈
             id: login_progress
             anchors.centerIn: login_button
             visible: false
         }
 
-        Button { // 登录按钮
+        Button {
+            // 登录按钮
             id: login_button
             anchors {
                 bottom: parent.bottom
@@ -180,15 +186,18 @@ Page {
 
             enabled: input_is_valid()
             onClicked: {
-                login_button.visible = false;
-                login_progress.visible = true;
-                request.url = "http://192.168.1.41:8893/login";
-                request.jsonData = JSON.stringify({ 'username': username.text, 'password': password.text });
-                request.sendJson();
+                login_button.visible = false
+                login_progress.visible = true
+                request.url = "http://192.168.1.41:8893/login"
+                request.jsonData = JSON.stringify({
+                                                      username: username.text,
+                                                      password: password.text
+                                                  })
+                request.sendJson()
             }
 
             function input_is_valid() {
-                return username.text !== "" && password.text !== "";
+                return username.text !== "" && password.text !== ""
             }
 
             Icon {
@@ -211,18 +220,22 @@ Page {
 
         onAccepted: {
             //保存当前用户名或密码逻辑
-            if((keep_username.checked == true)&&(keep_password.checked == false)){
-                usersetting.storeUser(username.text,'');
-            }else if((keep_username.checked == true)&&(keep_password.checked == true)){
-                usersetting.storeUser(username.text,password.text)
-            }else if(keep_username.checked == false){
-                usersetting.storeUser('','')
+            if ((keep_username.checked == true)
+                    && (keep_password.checked == false)) {
+                usersetting.storeUser(username.text, '')
+            } else if ((keep_username.checked == true)
+                       && (keep_password.checked == true)
+                       && (username.text !== '')) {
+                usersetting.storeUser(username.text, password.text)
+            } else if (keep_username.checked == false) {
+                usersetting.storeUser('', '')
             }
             Qt.quit()
         }
     }
 
-    Row { // 右下按钮栏
+    Row {
+        // 右下按钮栏
         anchors {
             bottom: parent.bottom
             bottomMargin: 32
@@ -262,7 +275,8 @@ Page {
         }
     }
 
-    Row { // 左下按钮栏
+    Row {
+        // 左下按钮栏
         anchors {
             bottom: parent.bottom
             bottomMargin: 32
@@ -287,34 +301,34 @@ Page {
         }
     }
 
-    Snackbar { // 通知栏
+    Snackbar {
+        // 通知栏
         id: prompt
     }
 
     Request {
         id: request
         onResponseChanged: {
-            var code = request.code;
-            var response = request.response;
+            var code = request.code
+            var response = request.response
 
-            login_progress.visible = false;
-            login_button.visible = true;
+            login_progress.visible = false
+            login_button.visible = true
 
             if (code === 401) {
-                username.hasError = true;
-                password.hasError = true;
-                password.helperText = "用户名或密码错误";
+                username.hasError = true
+                password.hasError = true
+                password.helperText = "用户名或密码错误"
             } else if (code === 500) {
                 prompt.open("服务暂时不可用")
             } else if (code === 200) {
-                UserConnection.username = username.text;
-                UserConnection.password = password.text;
-                UserConnection.info = response;
-                pageStack.push(Qt.resolvedUrl("DesktopPage.qml"));
+                UserConnection.username = username.text
+                UserConnection.password = password.text
+                UserConnection.info = response
+                pageStack.push(Qt.resolvedUrl("DesktopPage.qml"))
             } else {
                 prompt.open("连接服务器失败")
             }
         }
     }
-
 }

--- a/LoginPage.qml
+++ b/LoginPage.qml
@@ -108,7 +108,7 @@ Page {
 
             Switch {
                 id: keep_username
-                checked: false
+                checked: true
                 onCheckedChanged: function(){
                     if(keep_username.checked == true){
                        keep_password.enabled = true;
@@ -134,25 +134,31 @@ Page {
             Switch {
                 enabled: false
                 id: keep_password
-                checked: false
+                checked: true
             }
 
             Label {
                 text: "记住密码"
                 anchors.verticalCenter: keep_password.verticalCenter
             }
-
             Component.onCompleted:{
                 if(usersetting.user !== ''){
                     username.text = usersetting.user;
                     keep_username.checked = true;
+                }else{
+                    keep_username.checked = false;
                 }
 
                 if(usersetting.passwd !== ''){
                     password.text = usersetting.passwd;
+                    keep_password.enabled = true;
                     keep_password.checked = true;
+                }else{
+                    keep_password.enabled = false;
+                    keep_password.checked = false;
                 }
             }
+
         }
 
         ProgressCircle { // 登录过程中显示进度圈

--- a/main.cpp
+++ b/main.cpp
@@ -44,6 +44,10 @@ int main(int argc, char *argv[])
     QFont msyh_light("微软雅黑 Light");
     app.setFont(msyh_light);
 
+    app.setOrganizationName("HY");
+    app.setOrganizationDomain("HY.com");
+    app.setApplicationName("cloud-Client");
+
     QQmlApplicationEngine engine;
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
 

--- a/qml.qrc
+++ b/qml.qrc
@@ -7,5 +7,6 @@
         <file>settingPage/network.qml</file>
         <file>settingPage/protocol.qml</file>
         <file>settingPage/server.qml</file>
+        <file>settingPage/Settingstore.qml</file>
     </qresource>
 </RCC>

--- a/settingPage/Settingstore.qml
+++ b/settingPage/Settingstore.qml
@@ -1,0 +1,13 @@
+import Qt.labs.settings 1.0
+
+Settings {
+    id: settingConf
+    property string user: ""
+    property string passwd: ""
+
+    function storeUser(username,password){
+        settingConf.user = username;
+        settingConf.passwd = password;
+        console.log(username);
+    }
+}


### PR DESCRIPTION
#4 @solarsail @woqidaideshi

用settings实现了保存登陆用户信息功能。

测试方法：

1，可以先把服务器请求部分代码注释掉，然后输入用户名和密码，点击登陆。
2，用win+r，运行regedit，查看HKCU/SOFTWARE/HY/下的键值对是否保存。
3，只有保存用户名按钮checked时，才能继续点击保存密码按钮。下次启动时会根据之前保存的状态进行恢复。

目前存在的问题：
恢复的switch控件，只能滑动，不能点击。
