### PR TITLE
使记住密码开关与记住用户名开关行为一致

### DIFF
--- a/LoginPage.qml
+++ b/LoginPage.qml
@@ -68,13 +68,9 @@ Page {
             font.pixelSize: 24
 
             onTextChanged: {
-                username.hasError = false
-
+                username.hasError = false;
                 if (username.text === "") {
                     keep_username.checked = false
-                    keep_username.enabled = false
-                } else {
-                    keep_username.enabled = true
                 }
             }
 
@@ -96,8 +92,11 @@ Page {
             font.pixelSize: 24
 
             onTextChanged: {
-                password.hasError = false
-                password.helperText = ""
+                password.hasError = false;
+                password.helperText = "";
+                if (password.text === "") {
+                    keep_password.checked = false
+                }
             }
 
             width: 300
@@ -120,13 +119,11 @@ Page {
 
             Switch {
                 id: keep_username
+                enabled: username.text !== ""
                 checked: true
                 onCheckedChanged: function () {
-                    if (keep_username.checked == true) {
-                        keep_password.enabled = true
-                    } else {
+                    if (keep_username.checked == false) {
                         keep_password.checked = false
-                        keep_password.enabled = false
                     }
                 }
             }
@@ -145,6 +142,7 @@ Page {
 
             Switch {
                 id: keep_password
+                enabled: username.text !== "" && keep_username.checked
                 checked: true
             }
 

--- a/LoginPage.qml
+++ b/LoginPage.qml
@@ -142,7 +142,7 @@ Page {
 
             Switch {
                 id: keep_password
-                enabled: username.text !== "" && keep_username.checked
+                enabled: password.text !== "" && keep_username.checked
                 checked: true
             }
 


### PR DESCRIPTION
@rtty122333 

删除密码后关闭并禁用记住密码开关。

测试：
1. 编译运行
2. 输入用户名和密码，打开记住用户名和记住密码开关
3. 删除密码，记住密码开关已关闭并禁用
