### PR TITLE
增加修改单选按钮对齐的补丁

### DIFF
--- a/patch/0001-fix-radiobutton-center-alignment.patch
+++ b/patch/0001-fix-radiobutton-center-alignment.patch
@@ -1,0 +1,28 @@
+From cfce96535cc5fcbd8663c86a68a13b0c40376aa9 Mon Sep 17 00:00:00 2001
+From: solarsail <newleaf.lu@gmail.com>
+Date: Fri, 6 May 2016 11:21:52 +0800
+Subject: [PATCH] fix radiobutton center alignment
+
+---
+ modules/QtQuick/Controls/Styles/Material/RadioButtonStyle.qml | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/modules/QtQuick/Controls/Styles/Material/RadioButtonStyle.qml b/modules/QtQuick/Controls/Styles/Material/RadioButtonStyle.qml
+index 17cebad..b1922ee 100644
+--- a/modules/QtQuick/Controls/Styles/Material/RadioButtonStyle.qml
++++ b/modules/QtQuick/Controls/Styles/Material/RadioButtonStyle.qml
+@@ -51,7 +51,10 @@ RadioButtonStyle {
+         color: control.activeFocus ? Theme.alpha(control.color, 0.20) : "transparent"
+ 
+         Rectangle {
+-            anchors.centerIn: parent
++            anchors {
++                centerIn: parent
++                alignWhenCentered: false
++            }
+ 
+             implicitWidth: Units.dp(20)
+             implicitHeight: Units.dp(20)
+-- 
+2.7.1.windows.2
+


### PR DESCRIPTION
@rtty122333 

将按钮外圈设置为不强制按像素对齐。

测试：
1. 对 Material 库打补丁
2. 在界面中加入单选按钮，可以正确显示
