### PR TITLE
登录成功后删除没有选择保存的用户名或密码

### DIFF
--- a/LoginPage.qml
+++ b/LoginPage.qml
@@ -188,18 +188,18 @@ Page {
 
             enabled: input_is_valid()
             onClicked: {
-                login_button.visible = false
-                login_progress.visible = true
-                request.url = "http://192.168.1.41:8893/login"
+                login_button.visible = false;
+                login_progress.visible = true;
+                request.url = "http://192.168.1.41:8893/login";
                 request.jsonData = JSON.stringify({
                                                       username: username.text,
                                                       password: password.text
-                                                  })
-                request.sendJson()
+                                                  });
+                request.sendJson();
             }
 
             function input_is_valid() {
-                return username.text !== "" && password.text !== ""
+                return username.text !== "" && password.text !== "";
             }
 
             Icon {
@@ -228,7 +228,6 @@ Page {
             } else if ((keep_username.checked == true)
                        && (keep_password.checked == true)
                        && (username.text !== '')) {
-
                 usersetting.storeUser(username.text, password.text)
             } else if (keep_username.checked == false) {
                 usersetting.storeUser('', '')
@@ -312,25 +311,32 @@ Page {
     Request {
         id: request
         onResponseChanged: {
-            var code = request.code
-            var response = request.response
+            var code = request.code;
+            var response = request.response;
 
-            login_progress.visible = false
-            login_button.visible = true
+            login_progress.visible = false;
+            login_button.visible = true;
 
             if (code === 401) {
-                username.hasError = true
-                password.hasError = true
-                password.helperText = "用户名或密码错误"
+                username.hasError = true;
+                password.hasError = true;
+                password.helperText = "用户名或密码错误";
             } else if (code === 500) {
-                prompt.open("服务暂时不可用")
+                prompt.open("服务暂时不可用");
             } else if (code === 200) {
-                UserConnection.username = username.text
-                UserConnection.password = password.text
-                UserConnection.info = response
-                pageStack.push(Qt.resolvedUrl("DesktopPage.qml"))
+                UserConnection.username = username.text;
+                UserConnection.password = password.text;
+                UserConnection.info = response;
+                if (!keep_username.checked) {
+                    username.text = "";
+                }
+                if (!keep_password.checked) {
+                    password.text = "";
+                }
+
+                pageStack.push(Qt.resolvedUrl("DesktopPage.qml"));
             } else {
-                prompt.open("连接服务器失败")
+                prompt.open("连接服务器失败");
             }
         }
     }


### PR DESCRIPTION
resolve #10 

@rtty122333 

登录成功后，返回登录界面（即注销）时不再显示未保存的用户名或密码。

测试：

[A]
1. 只记住用户名
2. 成功登录
3. 返回
4. 用户名仍然保留，密码不被保留

[B]
1. 不记住用户名
2. 成功登录
3. 返回
4. 用户名和密码不被保留

[C]
1. 记住用户名和密码
2. 成功登录
3. 返回
4. 用户名和密码仍然保留
