### PR TITLE
取消 IP 自动配置复选框时，自动取消并禁用 DNS 自动配置复选框

### DIFF
--- a/settingPage/network.qml
+++ b/settingPage/network.qml
@@ -111,6 +111,7 @@ Item {
             CheckBox {
                 id: dnscheck
                 checked: true
+                enabled: ipcheck.checked
                 text: "DNS DHCP 自动设置"
                 darkBackground: false
                 onCheckedChanged:{

--- a/settingPage/network.qml
+++ b/settingPage/network.qml
@@ -55,6 +55,7 @@ Item {
                         ipfield.enabled = true;
                         submaskfield.enabled = true;
                         gatewayfield.enabled = true;
+                        dnscheck.checked = false;
                     } else {
                         ipfield.enabled = false;
                         submaskfield.enabled = false;


### PR DESCRIPTION
resolve #25 

@rtty122333 

与 Windows 配置保持一致。

测试：
1. 编译运行
2. 进入网络配置页面
3. 在任何情况下取消 IP 自动配置复选框，DNS 自动配置复选框自动取消并禁用
